### PR TITLE
feat(lze.h): lze.h[spec_field].handler_exported_function()

### DIFF
--- a/doc/lze.txt
+++ b/doc/lze.txt
@@ -70,6 +70,15 @@ lze.state                                                            *lze.state*
         (lze.State)
 
 
+lze.h                                                                    *lze.h*
+    Handlers may expose things by registering them in their lib table
+    require('lze').h.<spec_field>.<key>
+    wont populate unless used, will be removed if handler is removed
+
+    Type: ~
+        (table<string,table>)
+
+
                                              *lze.types*
 
 >lua
@@ -130,8 +139,8 @@ lze.state                                                            *lze.state*
   ---@field id string
   ---@field name string
   
-  ---@alias lze.Event {id:string, event:string[]|string, pattern?:string[]|string}
-  ---@alias lze.EventSpec string|{event?:string|string[], pattern?:string|string[]}|string[]
+  ---@alias lze.Event {id:string, event:string[]|string, pattern?:string[]|string, augroup:integer}
+  ---@alias lze.EventSpec string|{event?:string|string[], pattern?:string|string[], augroup?:integer}|string[]
   
   ---@class lze.SpecHandlers
   ---
@@ -204,6 +213,14 @@ lze.state                                                            *lze.state*
   ---Default: nil
   ---@field set_lazy? boolean
   ---
+  ---Handlers may export functions and other values via this set,
+  ---which then may be accessed via `require('lze').h[spec_field].your_func()`
+  ---@field lib? table
+  ---Called when the handler is registered
+  ---@field init? fun()
+  ---Allows you to clean up any global modifications your handler makes to the environment.
+  ---@field cleanup? fun()
+  ---
   ---runs at the end of require('lze').load()
   ---for handlers to set up extra triggers such as the
   ---event handler's DeferredUIEnter event
@@ -232,6 +249,12 @@ lze.state                                                            *lze.state*
   ---
   ---If false, lze will print error messages on fewer things.
   ---@field verbose? boolean
+  ---
+  ---Default priority for startup plugins. Defaults to 50 if unset
+  ---@field default_priority? integer
+  ---
+  ---If true, lze will not automatically register the default handlers.
+  ---@field without_default_handlers? boolean
   
   ---@type lze.Config
   vim.g.lze = vim.g.lze

--- a/lua/lze/c/parse.lua
+++ b/lua/lze/c/parse.lua
@@ -1,12 +1,9 @@
 -- needed so we can use stuff defined later in the file
 local lib = {}
 
--- It turns out that its faster when you copy paste.
--- Would be nice to just define it once, but then you lose 10ms
----@param spec lze.Plugin|lze.HandlerSpec|lze.SpecImport
-local function is_enabled(spec)
-    local disabled = spec.enabled == false or (type(spec.enabled) == "function" and not spec.enabled())
-    return not disabled
+---@param spec lze.Plugin|lze.SpecImport
+local function is_disabled(spec)
+    return spec.enabled == false or (type(spec.enabled) == "function" and not spec.enabled())
 end
 
 ---@param spec lze.SpecImport
@@ -23,7 +20,7 @@ local function import_spec(spec, result)
         end)
         return
     end
-    if not is_enabled(spec) then
+    if is_disabled(spec) then
         return
     end
     local modname = spec.import
@@ -86,7 +83,7 @@ function lib.normalize(spec, result)
         ---@cast spec lze.PluginSpec
         local parsed = parse(spec)
         if type(parsed) == "table" and type(parsed.name) == "string" then
-            if is_enabled(parsed) then
+            if not is_disabled(parsed) then
                 table.insert(result, parsed)
             end
         else

--- a/lua/lze/h/dep_of.lua
+++ b/lua/lze/h/dep_of.lua
@@ -6,7 +6,6 @@ local states = {}
 local trigger_load = require("lze.c.loader").load
 
 ---@type lze.Handler
----@diagnostic disable-next-line: missing-fields
 local M = {
     spec_field = "dep_of",
 }
@@ -49,6 +48,10 @@ function M.before(name)
         trigger_load(states[name])
         states[name] = nil
     end
+end
+
+function M.cleanup()
+    states = {}
 end
 
 return M

--- a/lua/lze/h/ft.lua
+++ b/lua/lze/h/ft.lua
@@ -1,21 +1,27 @@
 -- NOTE: simply an alias for lze.h.event for filetype
 local event = require("lze.h.event")
 
----@class lze.FtHandler: lze.Handler
----@field parse fun(spec: lze.EventSpec): lze.Event
+local states = {}
 
----@type lze.FtHandler
+local augroup = nil
+
+local parse = function(value)
+    return {
+        id = value,
+        event = "FileType",
+        pattern = value,
+        augroup = augroup,
+    }
+end
+
+---@type lze.Handler
 local M = {
-    pending = {},
     spec_field = "ft",
-    ---@param value string
-    ---@return lze.Event
-    parse = function(value)
-        return {
-            id = value,
-            event = "FileType",
-            pattern = value,
-        }
+    lib = {
+        parse = parse,
+    },
+    init = function()
+        augroup = vim.api.nvim_create_augroup("lze_handler_ft", { clear = true })
     end,
 }
 
@@ -28,23 +34,37 @@ function M.add(plugin)
     ---@type lze.Event[]
     plugin.event = {}
     if type(ft_spec) == "string" then
-        local ft = M.parse(ft_spec)
+        local ft = parse(ft_spec)
         ---@diagnostic disable-next-line: param-type-mismatch
         table.insert(plugin.event, ft)
     elseif type(ft_spec) == "table" then
         ---@param ft_spec_ string
         vim.iter(ft_spec):each(function(ft_spec_)
-            local ft = M.parse(ft_spec_)
+            local ft = parse(ft_spec_)
             ---@diagnostic disable-next-line: param-type-mismatch
             table.insert(plugin.event, ft)
         end)
     end
+    states[plugin.name] = true
     event.add(plugin)
 end
 
 ---@param name string
 function M.before(name)
-    event.before(name)
+    if states[name] then
+        event.before(name)
+        states[name] = nil
+    end
+end
+
+function M.cleanup()
+    for name, _ in pairs(states) do
+        event.before(name)
+    end
+    states = {}
+    if augroup then
+        vim.api.nvim_del_augroup_by_id(augroup)
+    end
 end
 
 return M

--- a/lua/lze/h/on_plugin.lua
+++ b/lua/lze/h/on_plugin.lua
@@ -6,7 +6,6 @@ local trigger_load = require("lze.c.loader").load
 local states = {}
 
 ---@type lze.Handler
----@diagnostic disable-next-line: missing-fields
 local M = {
     spec_field = "on_plugin",
 }
@@ -49,6 +48,10 @@ function M.after(name)
         trigger_load(states[name])
         states[name] = nil
     end
+end
+
+function M.cleanup()
+    states = {}
 end
 
 return M

--- a/lua/lze/h/on_require.lua
+++ b/lua/lze/h/on_require.lua
@@ -9,7 +9,7 @@ local states = {}
 -- replacing the global require function
 
 local old_require = require
-require("_G").require = function(mod_path)
+local new_require = function(mod_path)
     local ok, value = pcall(old_require, mod_path)
     if ok then
         return value
@@ -33,13 +33,18 @@ end
 ---@field on_require? string[]|string
 
 ---@type lze.Handler
----@diagnostic disable-next-line: missing-fields
 local M = {
-    old_require = old_require,
     spec_field = "on_require",
     ---@param name string
     before = function(name)
         states[name] = nil
+    end,
+    init = function()
+        _G.require = new_require
+    end,
+    cleanup = function()
+        _G.require = old_require
+        states = {}
     end,
 }
 

--- a/lua/lze/init.lua
+++ b/lua/lze/init.lua
@@ -52,4 +52,10 @@ lze.load = require("lze.c.loader").define
 ---@type lze.State
 lze.state = require("lze.c.loader").state
 
+---Handlers may expose things by registering them in their lib table
+---require('lze').h.<spec_field>.<key>
+---wont populate unless used, will be removed if handler is removed
+---@type table<string, table>
+lze.h = require("lze.c.handler").libs
+
 return lze

--- a/lua/lze/meta.lua
+++ b/lua/lze/meta.lua
@@ -55,8 +55,8 @@ error("Cannot import a meta module")
 ---@field id string
 ---@field name string
 
----@alias lze.Event {id:string, event:string[]|string, pattern?:string[]|string}
----@alias lze.EventSpec string|{event?:string|string[], pattern?:string|string[]}|string[]
+---@alias lze.Event {id:string, event:string[]|string, pattern?:string[]|string, augroup:integer}
+---@alias lze.EventSpec string|{event?:string|string[], pattern?:string|string[], augroup?:integer}|string[]
 
 ---@class lze.SpecHandlers
 ---
@@ -129,6 +129,14 @@ error("Cannot import a meta module")
 ---Default: nil
 ---@field set_lazy? boolean
 ---
+---Handlers may export functions and other values via this set,
+---which then may be accessed via `require('lze').h[spec_field].your_func()`
+---@field lib? table
+---Called when the handler is registered
+---@field init? fun()
+---Allows you to clean up any global modifications your handler makes to the environment.
+---@field cleanup? fun()
+---
 ---runs at the end of require('lze').load()
 ---for handlers to set up extra triggers such as the
 ---event handler's DeferredUIEnter event
@@ -157,6 +165,12 @@ error("Cannot import a meta module")
 ---
 ---If false, lze will print error messages on fewer things.
 ---@field verbose? boolean
+---
+---Default priority for startup plugins. Defaults to 50 if unset
+---@field default_priority? integer
+---
+---If true, lze will not automatically register the default handlers.
+---@field without_default_handlers? boolean
 
 ---@type lze.Config
 vim.g.lze = vim.g.lze

--- a/spec/event_spec.lua
+++ b/spec/event_spec.lua
@@ -3,53 +3,51 @@ vim.g.lze = {
     load = function() end,
 }
 local lze = require("lze")
-local event = require("lze.h.event")
 local loader = require("lze.c.loader")
 local spy = require("luassert.spy")
 
 describe("handlers.event", function()
     it("can parse from string", function()
-        assert.same({
+        local f = function(inspec, evstr)
+            local res = lze.h.event.parse(evstr)
+            assert.Same(inspec.event, res.event)
+            assert.Same(inspec.pattern, res.pattern)
+            assert.Same(inspec.id, res.id)
+        end
+        f({
             event = "VimEnter",
             id = "VimEnter",
-        }, event.parse("VimEnter"))
+        }, "VimEnter")
     end)
     it("can parse from table", function()
-        assert.same(
-            {
-                event = "VimEnter",
-                id = "VimEnter",
-            },
-            event.parse({
-                event = "VimEnter",
+        local f = function(inspec)
+            local res = lze.h.event.parse({
+                event = inspec.event,
+                pattern = inspec.pattern,
             })
-        )
-        assert.same(
-            {
-                event = { "VimEnter", "BufEnter" },
-                id = "VimEnter|BufEnter",
-            },
-            event.parse({
-                event = { "VimEnter", "BufEnter" },
-            })
-        )
-        assert.same(
-            {
-                event = "BufEnter",
-                id = "BufEnter *.lua",
-                pattern = "*.lua",
-            },
-            event.parse({
-                event = "BufEnter",
-                pattern = "*.lua",
-            })
-        )
+            assert.Same(inspec.event, res.event)
+            assert.Same(inspec.pattern, res.pattern)
+            assert.Same(inspec.id, res.id)
+        end
+        f({
+            event = "VimEnter",
+            id = "VimEnter",
+        })
+        f({
+            event = { "VimEnter", "BufEnter" },
+            id = "VimEnter|BufEnter",
+        })
+        f({
+            event = "BufEnter",
+            id = "BufEnter *.lua",
+            pattern = "*.lua",
+        })
     end)
     it("Event only loads plugin once", function()
         ---@type lze.Plugin
         local plugin = {
             name = "foo",
-            event = { event.parse("BufEnter") },
+            event = { lze.h.event.parse("BufEnter") },
         }
         local spy_load = spy.on(loader, "load")
         lze.load(plugin)
@@ -83,15 +81,15 @@ describe("handlers.event", function()
             assert.Equal(1, called_number[plugin.name])
             assert.False(lze.state(plugin.name))
         end
-        itt({ event.parse("BufEnter"), event.parse("WinEnter") }, "foo2")
-        itt({ event.parse("WinEnter"), event.parse("BufEnter") }, "foo3")
+        itt({ lze.h.event.parse("BufEnter"), lze.h.event.parse("WinEnter") }, "foo2")
+        itt({ lze.h.event.parse("WinEnter"), lze.h.event.parse("BufEnter") }, "foo3")
     end)
     it("Plugins' event handlers are triggered", function()
         local triggered = false
         ---@type lze.Plugin
         local plugin = {
             name = "foo6",
-            event = { event.parse("BufEnter") },
+            event = { lze.h.event.parse("BufEnter") },
             after = function()
                 triggered = true
             end,
@@ -106,7 +104,7 @@ describe("handlers.event", function()
         ---@type lze.Plugin
         local plugin = {
             name = "bla",
-            event = { event.parse("DeferredUIEnter") },
+            event = { lze.h.event.parse("DeferredUIEnter") },
         }
         local spy_load = spy.on(loader, "load")
         lze.load(plugin)

--- a/spec/ft_spec.lua
+++ b/spec/ft_spec.lua
@@ -3,17 +3,22 @@ vim.g.lze = {
     load = function() end,
 }
 local lze = require("lze")
-local ft = require("lze.h.ft")
 local loader = require("lze.c.loader")
 local spy = require("luassert.spy")
 
 describe("handlers.ft", function()
     it("can parse from string", function()
-        assert.same({
+        local f = function(inspec, ft)
+            local res = lze.h.ft.parse(ft)
+            assert.Same(inspec.event, res.event)
+            assert.Same(inspec.pattern, res.pattern)
+            assert.Same(inspec.id, res.id)
+        end
+        f({
             event = "FileType",
             id = "rust",
             pattern = "rust",
-        }, ft.parse("rust"))
+        }, "rust")
     end)
     it("filetype event loads plugins", function()
         ---@type lze.Plugin

--- a/spec/keys_spec.lua
+++ b/spec/keys_spec.lua
@@ -3,7 +3,6 @@ vim.g.lze = {
     load = function() end,
 }
 local lze = require("lze")
-local keys = require("lze.h.keys")
 local loader = require("lze.c.loader")
 local spy = require("luassert.spy")
 
@@ -16,9 +15,9 @@ describe("handlers.keys", function()
         }
         for _, test in ipairs(tests) do
             if test[3] then
-                assert.same(keys.parse(test[1])[1].id, keys.parse(test[2])[1].id)
+                assert.same(lze.h.keys.parse(test[1])[1].id, lze.h.keys.parse(test[2])[1].id)
             else
-                assert.is_not.same(keys.parse(test[1])[1].id, keys.parse(test[2])[1].id)
+                assert.is_not.same(lze.h.keys.parse(test[1])[1].id, lze.h.keys.parse(test[2])[1].id)
             end
         end
     end)
@@ -43,7 +42,7 @@ describe("handlers.keys", function()
             local timesloaded = 0
             local parsed_keys = {}
             for _, key in ipairs(lzkeys) do
-                table.insert(parsed_keys, keys.parse(key)[1])
+                table.insert(parsed_keys, lze.h.keys.parse(key)[1])
             end
             ---@type lze.Plugin
             local plugin = {

--- a/spec/lze_spec.lua
+++ b/spec/lze_spec.lua
@@ -7,6 +7,16 @@ local spy = require("luassert.spy")
 
 describe("lze", function()
     describe("load", function()
+        it("__len works", function()
+            assert.True(#lz.state == 0)
+            lz.load({
+                {
+                    "neorgblahblahblah",
+                    lazy = true,
+                },
+            })
+            assert.True(#lz.state == 1)
+        end)
         it("list of plugin specs", function()
             local spy_load = spy.on(loader, "load")
             lz.load({

--- a/spec/nested_event_spec.lua
+++ b/spec/nested_event_spec.lua
@@ -14,10 +14,13 @@ describe("nested events", function()
                 after = function()
                     pcall(vim.cmd.colorscheme, "sick_colorscheme_bruh")
                 end,
-                load = function() end,
+                load = function()
+                    vim.g.event_nested_works = true
+                end,
             },
         })
         vim.api.nvim_exec_autocmds("UIEnter", {})
+        assert.True(vim.g.event_nested_works)
         assert.True(vim.g.sweetie_nvim_loaded)
     end)
 end)


### PR DESCRIPTION
Handlers also have optional lifecycle hooks for making your handler work better with being disabled and then reenabled and clearing internal state if necessary

modify no longer called if the plugin is disabled already